### PR TITLE
Silencing clippy warnings

### DIFF
--- a/app/game/src/components/energy_cell.rs
+++ b/app/game/src/components/energy_cell.rs
@@ -1,0 +1,32 @@
+use crate::components::sunray::Sunray;
+#[allow(unused)]
+pub struct EnergyCell {
+    charge: bool,
+}
+
+#[allow(dead_code)]
+impl EnergyCell {
+    pub fn new() -> Self {
+        Self { charge: false }
+    }
+
+    pub fn charge(&mut self, _sunray: Sunray) {
+        if !self.charge {
+            self.charge = true;
+        }
+        // if the cell is already charged nothing happens, the Sunray is wasted
+    }
+
+    pub fn discharge(&mut self) -> Result<(), String> {
+        if self.charge {
+            self.charge = false;
+            Ok(())
+        } else {
+            Err("EnergyCell not charged!".to_string())
+        }
+    }
+
+    pub fn is_charged(&self) -> bool {
+        self.charge
+    }
+}

--- a/app/game/src/components/sunray.rs
+++ b/app/game/src/components/sunray.rs
@@ -1,0 +1,7 @@
+pub struct Sunray;
+#[allow(unused)]
+impl Sunray {
+    pub(crate) fn new() -> Sunray {
+        Sunray
+    }
+}

--- a/app/game/src/protocols/orchestrator.rs
+++ b/app/game/src/protocols/orchestrator.rs
@@ -1,0 +1,4 @@
+#[allow(unused)]
+pub trait Orchestrator {
+    // to be defined
+}

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ fmt:
     cargo fmt
 
 lint:
-    cargo clippy
+    cargo clippy -- -D warnings
 
 test:
     cargo test


### PR DESCRIPTION
Basic structure for the project

The same as the previous PR but with silenced warnings from clippy (to be removed later on during development)
Justfile now shows cargo clippy -- -D warnings so that 'just ci' on local is as strict as it is on github actions


