### PR TITLE
Add private field, default trait and docs to Sunray struct

### DIFF
--- a/app/game/src/components/sunray.rs
+++ b/app/game/src/components/sunray.rs
@@ -1,8 +1,24 @@
-#[allow(dead_code)] //temporary clippy silencer
-pub struct Sunray;
+/// Represents a sunray object, instanciable by the orchestrator.
+pub struct Sunray {
+    _private: (),
+}
 #[allow(dead_code)]
+impl Default for Sunray {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Sunray {
-    pub(crate) fn new() -> Sunray {
-        Sunray
+    /// Creates a new, default instance of a [Sunray].
+    ///
+    /// This method is the basic constructor and does not require any
+    /// specific initial parameters.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new instance of [Sunray].
+    pub fn new() -> Sunray {
+        Sunray { _private: () }
     }
 }


### PR DESCRIPTION
Now sunray and asteroid have the same implementation, necessary for the orchestrator