### PR TITLE
Planet improvements (again)

### DIFF
--- a/app/game/src/protocols/messages.rs
+++ b/app/game/src/protocols/messages.rs
@@ -9,58 +9,55 @@ use crate::components::resource::{
     BasicResource, BasicResourceType, ComplexResource, ComplexResourceRequest, ComplexResourceType,
     GenericResource,
 };
-use crate::components::rocket::Rocket;
 use crate::components::sunray::Sunray;
 use std::collections::HashSet;
 use std::sync::mpsc;
 
 /// Messages sent by the `Orchestrator` to a `Planet`.
 pub enum OrchestratorToPlanet {
-    ///This variant is used to send a [Sunray] to a planet
+    /// This variant is used to send a [Sunray] to a planet
     Sunray(Sunray),
-    ///This variant is used to send an [Asteroid] to a planet
+    /// This variant is used to send an [Asteroid] to a planet
     Asteroid(Asteroid),
-    ///This variant is used to start a Planet Ai and restart it if it is stopped
+    /// This variant is used to start a Planet Ai and restart it if it is stopped
     StartPlanetAI,
-    ///This variant is used to pause the planet Ai
+    /// This variant is used to pause the planet Ai
     StopPlanetAI,
-    ///This variant is used to obtain a Planet Internal State
+    /// This variant is used to obtain a Planet Internal State
     InternalStateRequest,
-    ///This variant is used to send the new [mpsc::Sender] of the incoming explorer, see the sequence diagram for more info
+    /// This variant is used to send the new [mpsc::Sender] of the incoming explorer, see the sequence diagram for more info
     IncomingExplorerRequest {
         explorer_id: u32,
         new_mpsc_sender: mpsc::Sender<PlanetToExplorer>,
     },
-    ///This variant is used to notify the planet to drop the [mpsc::Sender] of the outgoing explorer
+    /// This variant is used to notify the planet to drop the [mpsc::Sender] of the outgoing explorer
     OutgoingExplorerRequest { explorer_id: u32 },
 }
 
 /// Messages sent by a `Planet` to the `Orchestrator`.
 pub enum PlanetToOrchestrator {
-    ///This variant is used to acknowledge the obtained [Sunray]
+    /// This variant is used to acknowledge the obtained [Sunray]
     SunrayAck { planet_id: u32 },
-    ///This variant is used to acknowledge the obtained [Asteroid] and sends back the optional [Rocket] of the defending planet
-    AsteroidAck {
-        planet_id: u32,
-        rocket: Option<Rocket>,
-    },
-    ///This variant is used to acknowledge the start of the Planet Ai
+    /// This variant is used to acknowledge the obtained [Asteroid] and notify the orchestrator
+    /// if the planet has been destroyed or not.
+    AsteroidAck { planet_id: u32, destroyed: bool },
+    /// This variant is used to acknowledge the start of the Planet Ai
     StartPlanetAIResult { planet_id: u32 },
-    ///This variant is used to acknowledge the stop of the Planet Ai
+    /// This variant is used to acknowledge the stop of the Planet Ai
     StopPlanetAIResult { planet_id: u32 },
-    ///This variant is used to send back the Planet State
+    /// This variant is used to send back the Planet State
     InternalStateResponse {
         planet_id: u32,
         planet_state: DummyPlanetState,
     },
-    ///This variant is used to acknowledge the incoming explorer
-    ///Encapsulates a [Result] with a possible [Err] String representing an error occurred
+    /// This variant is used to acknowledge the incoming explorer
+    /// Encapsulates a [Result] with a possible [Err] String representing an error occurred
     IncomingExplorerResponse {
         planet_id: u32,
         res: Result<(), String>,
     },
-    ///This variant is used to acknowledge the outgoing explorer
-    ///Encapsulates a [Result] with a possible [Err] String representing an error occurred
+    /// This variant is used to acknowledge the outgoing explorer
+    /// Encapsulates a [Result] with a possible [Err] String representing an error occurred
     OutgoingExplorerResponse {
         planet_id: u32,
         res: Result<(), String>,
@@ -69,55 +66,55 @@ pub enum PlanetToOrchestrator {
 
 /// Messages sent by the `Orchestrator` to an `Explorer`.
 pub enum OrchestratorToExplorer {
-    ///This variant is used to start the Explorer AI
+    /// This variant is used to start the Explorer AI
     StartExplorerAI,
-    ///This variant is used to reset the Explorer AI
+    /// This variant is used to reset the Explorer AI
     ResetExplorerAI,
-    ///This variant is used to kill the Explorer AI
+    /// This variant is used to kill the Explorer AI
     KillExplorerAI,
-    ///This variant is used to send a [mpsc::Sender] to the new planet
+    /// This variant is used to send a [mpsc::Sender] to the new planet
     MoveToPlanet {
         sender_to_new_planet: Option<mpsc::Sender<ExplorerToPlanet>>,
     }, //none if explorer asks to move to a non-adjacent planet,
-    ///This variant is used to ask the ID of the Planet in which the Explorer is currently located
+    /// This variant is used to ask the ID of the Planet in which the Explorer is currently located
     CurrentPlanetRequest,
-    ///This variant is used to enforce the Explorer to ask the supported Resources on the Planet
+    /// This variant is used to enforce the Explorer to ask the supported Resources on the Planet
     SupportedResourceRequest,
-    ///This variant is used to enforce the Explorer to ask the supported Combinations on the Planet
+    /// This variant is used to enforce the Explorer to ask the supported Combinations on the Planet
     SupportedCombinationRequest,
-    ///This variant is used to enforce the Explorer to ask the Planet to Generate a [BasicResource]
+    /// This variant is used to enforce the Explorer to ask the Planet to Generate a [BasicResource]
     GenerateResourceRequest { to_generate: BasicResourceType },
-    ///This variant is used to enforce the Explorer to ask the Planet to Generate a [ComplexResource] using the [ComplexResourceRequest]
+    /// This variant is used to enforce the Explorer to ask the Planet to Generate a [ComplexResource] using the [ComplexResourceRequest]
     CombineResourceRequest(ComplexResourceRequest),
-    ///This variant is used to ask the content of the Explorer Bag
+    /// This variant is used to ask the content of the Explorer Bag
     BagContentRequest,
-    ///This variant is used to send to the Explorer its neighbors' IDs
+    /// This variant is used to send to the Explorer its neighbors' IDs
     NeighborsResponse { neighbors: Vec<u32> },
 }
 
 /// Messages sent by an `Explorer` to the `Orchestrator`.
 pub enum ExplorerToOrchestrator<T> {
-    ///Acknowledge of [OrchestratorToExplorer::StartExplorerAI]
+    /// Acknowledge of [OrchestratorToExplorer::StartExplorerAI]
     StartExplorerAIResult { explorer_id: u32 },
-    ///Acknowledge of [OrchestratorToExplorer::KillExplorerAI]
+    /// Acknowledge of [OrchestratorToExplorer::KillExplorerAI]
     KillExplorerAIResult { explorer_id: u32 },
-    ///Acknowledge of [OrchestratorToExplorer::ResetExplorerAI]
+    /// Acknowledge of [OrchestratorToExplorer::ResetExplorerAI]
     ResetExplorerAIResult { explorer_id: u32 },
-    ///Acknowledge of [OrchestratorToExplorer::MoveToPlanet]
+    /// Acknowledge of [OrchestratorToExplorer::MoveToPlanet]
     MovedToPlanetResult { explorer_id: u32 },
-    ///This variant is used to send the ID of the current planet on which the Explorer is located
+    /// This variant is used to send the ID of the current planet on which the Explorer is located
     CurrentPlanetResult { explorer_id: u32, planet_id: u32 },
-    ///This variant is used to send the list of the available [BasicResourceType] in the planet
+    /// This variant is used to send the list of the available [BasicResourceType] in the planet
     SupportedResourceResult {
         explorer_id: u32,
         supported_resources: HashSet<BasicResourceType>,
     },
-    ///This variant is used to send the list of the available [ComplexResourceType] in the planet
+    /// This variant is used to send the list of the available [ComplexResourceType] in the planet
     SupportedCombinationResult {
         explorer_id: u32,
         combination_list: HashSet<ComplexResourceType>,
     },
-    ///This variant holds a [Result] for the Orchestrator to know if the requested [BasicResource] has been generated
+    /// This variant holds a [Result] for the Orchestrator to know if the requested [BasicResource] has been generated
     GenerateResourceResponse {
         explorer_id: u32,
         generated: Result<(), ()>,
@@ -150,12 +147,12 @@ pub enum ExplorerToOrchestrator<T> {
     /// ```
     ///
     BagContentResponse { explorer_id: u32, bag_content: T },
-    ///This variant asks the Orchestrator for the list of neighbors Planets to travel to
+    /// This variant asks the Orchestrator for the list of neighbors Planets to travel to
     NeighborsRequest {
         explorer_id: u32,
         current_planet_id: u32,
     },
-    ///This variant asks the Orchestrator to be sent to the specified Planet
+    /// This variant asks the Orchestrator to be sent to the specified Planet
     TravelToPlanetRequest {
         explorer_id: u32,
         current_planet_id: u32,
@@ -164,8 +161,8 @@ pub enum ExplorerToOrchestrator<T> {
 }
 
 impl<T> ExplorerToOrchestrator<T> {
-    /// Helper method to extract the `explorer_id` from any message variant
-    /// without needing to match the specific enum variant.
+    /// Helper method to extract the `explorer_id` field from any message variant
+    /// without needing to match a specific one.
     pub fn explorer_id(&self) -> u32 {
         match self {
             Self::StartExplorerAIResult { explorer_id, .. } => *explorer_id,
@@ -186,27 +183,27 @@ impl<T> ExplorerToOrchestrator<T> {
 
 /// Messages sent by an `Explorer` to a `Planet`.
 pub enum ExplorerToPlanet {
-    ///This variant is used to ask the Planet for the available [BasicResourceType]
+    /// This variant is used to ask the Planet for the available [BasicResourceType]
     SupportedResourceRequest { explorer_id: u32 },
-    ///This variant is used to ask the Planet for the available [ComplexResourceType]
+    /// This variant is used to ask the Planet for the available [ComplexResourceType]
     SupportedCombinationRequest { explorer_id: u32 },
-    ///This variant is used to ask the Planet to generate a [BasicResource]
+    /// This variant is used to ask the Planet to generate a [BasicResource]
     GenerateResourceRequest {
         explorer_id: u32,
         resource: BasicResourceType,
     },
-    ///This variant is used to ask the Planet to generate a [ComplexResource] using the [ComplexResourceRequest]
+    /// This variant is used to ask the Planet to generate a [ComplexResource] using the [ComplexResourceRequest]
     CombineResourceRequest {
         explorer_id: u32,
         msg: ComplexResourceRequest,
     },
-    ///This variant is used to ask the Planet for the available energy_cells number
+    /// This variant is used to ask the Planet for the available energy_cells number
     AvailableEnergyCellRequest { explorer_id: u32 },
 }
 
 impl ExplorerToPlanet {
-    /// Helper method to extract the `explorer_id` from any message variant
-    /// without needing to match the specific enum variant.
+    /// Helper method to extract the `explorer_id` field from any message variant
+    /// without needing to match a specific one.
     pub fn explorer_id(&self) -> u32 {
         match self {
             ExplorerToPlanet::SupportedResourceRequest { explorer_id, .. } => *explorer_id,
@@ -220,22 +217,22 @@ impl ExplorerToPlanet {
 
 /// Messages sent by a `Planet` to an `Explorer`.
 pub enum PlanetToExplorer {
-    ///This variant is used to send the available [BasicResourceType] list to the Explorer
+    /// This variant is used to send the available [BasicResourceType] list to the Explorer
     SupportedResourceResponse {
         resource_list: HashSet<BasicResourceType>,
     },
-    ///This variant is used to send the available [ComplexResourceType] list to the Explorer
+    /// This variant is used to send the available [ComplexResourceType] list to the Explorer
     SupportedCombinationResponse {
         combination_list: HashSet<ComplexResourceType>,
     },
-    ///This variant is used to send the Optional [BasicResource] generated or [None] in case of errors
+    /// This variant is used to send the Optional [BasicResource] generated or [None] in case of errors
     GenerateResourceResponse { resource: Option<BasicResource> },
-    ///This variant is used to send the [ComplexResource] generated
-    ///It contains a [Result] giving back the [ComplexResource] in case of success
-    ///and a triplet containing an error string and the two [GenericResource] provided by the Explorer
+    /// This variant is used to send the [ComplexResource] generated
+    /// It contains a [Result] giving back the [ComplexResource] in case of success
+    /// and a triplet containing an error string and the two [GenericResource] provided by the Explorer
     CombineResourceResponse {
         complex_response: Result<ComplexResource, (String, GenericResource, GenericResource)>,
     },
-    ///This variant is used to send the number of available energy cells to the Explorer
+    /// This variant is used to send the number of available energy cells to the Explorer
     AvailableEnergyCellResponse { available_cells: u32 },
 }


### PR DESCRIPTION
This PR fixes issue #62 and modifies how te planet destruction logic works. Now the planet "kills himself", returning from the main `run` method when no `Rocket` is returned from `PlanetAI::handle_asteroid()`. Changed the `AstroidAck` message to work with this.