### PR TITLE
New `PlanetAI` trait

### DIFF
--- a/app/game/src/protocols/messages.rs
+++ b/app/game/src/protocols/messages.rs
@@ -25,7 +25,7 @@ pub enum OrchestratorToPlanet {
     StartPlanetAI,
     /// This variant is used to pause the planet Ai
     StopPlanetAI,
-    /// This variant is used to kill (destroy) the planet
+    /// This variant is used to kill (or destroy) the planet
     KillPlanet,
     /// This variant is used to obtain a Planet Internal State
     InternalStateRequest,


### PR DESCRIPTION
Updated `PlanetAI` trait with specialised handlers and removed generic handler `handle_orchestrator_msg`. Also added optional (with empty default implementation) listener methods for explorers arrival/departure. This PR tries to fix  issues #97 and #93.