### PR TITLE
docs: moved architecture documentation into cargo doc

### DIFF
--- a/app/game/src/components.rs
+++ b/app/game/src/components.rs
@@ -1,3 +1,52 @@
+//! # Components
+//!
+//! This module defines all **core game entities** shared across implementations
+//! of the Advanced Programming project.
+//!
+//! Components represent concrete objects that exist in the simulation, such as
+//! planets, explorers, energy-related entities, and resources.
+//!
+//! ## Responsibilities of components
+//! - Encode domain concepts as strongly typed Rust structures
+//! - Enforce system-wide invariants at construction time
+//! - Prevent illegal states through restricted constructors
+//! - Serve as the only valid data exchanged through protocols
+//!
+//! ## Creation and ownership rules
+//! Some components are **user-inconstructible** and can only be created by
+//! privileged system actors:
+//! - **Forge** is a singleton and is the sole creator of `Sunray` and `Asteroid`
+//! - `Sunray` and `Asteroid` instances cannot be constructed directly by users
+//! - Rockets can only be built through controlled energy consumption
+//!
+//! These restrictions are enforced to prevent inconsistent or invalid system
+//! states.
+//!
+//! ## Energy and resources
+//! Energy is represented explicitly via `EnergyCell`s, which have a **binary
+//! charged / uncharged state**. Energy consumption is required for:
+//! - Basic resource generation
+//! - Complex resource combination
+//! - Rocket construction
+//!
+//! Resources are divided into **basic** and **complex** types. Complex resources
+//! can only be obtained by combining specific basic or complex inputs according
+//! to predefined recipes.
+//!
+//! ## Planet constraints
+//! Planet behavior is restricted by its declared type. Depending on the type,
+//! a planet may:
+//! - Have a limited or unlimited number of energy cells
+//! - Support a bounded or unbounded number of resource recipes
+//! - Be allowed or forbidden from owning rockets
+//!
+//! These constraints are validated during planet construction and must not be
+//! bypassed by implementations.
+//!
+//! ## Communication
+//! Components do not communicate directly with each other. All interactions
+//! occur through the message protocols defined in the `protocols` module.
+
 pub mod asteroid;
 pub mod energy_cell;
 pub mod planet;

--- a/app/game/src/lib.rs
+++ b/app/game/src/lib.rs
@@ -1,3 +1,44 @@
+//! # Common Game Crate
+//!
+//! This crate defines the shared architecture, components, and communication
+//! protocols used by all implementations of the **Advanced Programming** course
+//! project.
+//!
+//! It exists to allow **independent teams ("contractors")** to develop planets,
+//! explorers, orchestrators, and other components that are guaranteed to be
+//! compatible with each other at integration time.
+//!
+//! ## What this crate provides
+//! - Public, stable interfaces for all core game entities
+//! - Message-based protocols for inter-component communication
+//! - Strong invariants enforced through the Rust type system
+//! - Runtime validation of architectural constraints
+//!
+//! This crate intentionally focuses on **interfaces and behavior**, not on
+//! internal implementation details.
+//!
+//! ## Design principles
+//! - **Protocol-first design**: all interactions occur via typed messages
+//! - **User-inconstructible critical types**: some entities can only be created
+//! by privileged components
+//! - **Explicit failure modes**: no undocumented panics
+//! - **No `unsafe` code**: memory safety is fully guaranteed
+//! - **Clippy-pedantic compliance**: high code quality is expected
+//!
+//! ## Architectural overview
+//! The system is composed of three main actor types:
+//! - **Orchestrator**: coordinates the simulation and message routing
+//! - **Planets**: stateful entities that manage energy and resources
+//! - **Explorers**: mobile agents that travel between planets
+//!
+//! All actors communicate exclusively through the protocols defined in this
+//! crate. Direct shared-memory interaction between actors is forbidden.
+//!
+//! ## Source of truth
+//! This documentation, generated via `cargo doc`, is the **authoritative
+//! reference** for the project. External documents (e.g. PDFs) are considered
+//! obsolete and non-normative.
+
 pub mod components;
 pub mod logging;
 pub mod protocols;

--- a/app/game/src/protocols.rs
+++ b/app/game/src/protocols.rs
@@ -1,1 +1,42 @@
+//! # Communication Protocols
+//!
+//! This module defines all **message-based communication protocols** used by
+//! the actors in the system.
+//!
+//! Protocols specify *what* messages can be exchanged, *who* can send them,
+//! and *which responses are required*. They form the backbone of all
+//! inter-component interaction.
+//!
+//! ## Actor pairs
+//! The system defines explicit protocols for the following actor pairs:
+//! - Orchestrator ↔ Planet
+//! - Planet ↔ Explorer
+//! - Orchestrator ↔ Explorer
+//!
+//! No other communication paths are allowed.
+//!
+//! ## Message guarantees
+//! Protocols enforce several global guarantees:
+//! - Certain messages require **mandatory acknowledgments**
+//! - Actors in a stopped state must respond deterministically
+//! - Termination messages (`Kill*`) are always honored
+//! - Planet destruction may trigger cascading termination of explorers
+//!
+//! These rules ensure that the system remains observable, debuggable, and
+//! free of deadlocks or undefined behavior.
+//!
+//! ## Failure handling
+//! Errors are represented explicitly in message payloads rather than through
+//! panics. When an operation fails, messages include sufficient information
+//! to allow the sender to recover or retry.
+//!
+//! ## Determinism and safety
+//! All protocols are designed to be:
+//! - Deterministic
+//! - Fully type-checked at compile time
+//! - Independent of concrete actor implementations
+//!
+//! This allows heterogeneous implementations to interoperate safely without
+//! requiring shared internal logic.
+
 pub mod messages;


### PR DESCRIPTION
This PR migrates the architectural documentation from the PDF into Rust doc
comments rendered by `cargo doc`.

**Added:**
- Crate-level documentation in `lib.rs`
- High-level documentation for `components` module
- High-level documentation for `protocols` module

This establishes `cargo doc` as the **single source of truth** for project
architecture and public interfaces.